### PR TITLE
fix: websocket connections dropping when idle

### DIFF
--- a/src/api/socket/custom-ws-adaptor.ts
+++ b/src/api/socket/custom-ws-adaptor.ts
@@ -79,6 +79,33 @@ export class CustomWsAdaptor extends WsAdapter {
               socket,
               head,
               (client: WebSocket) => {
+                const pingInterval = setInterval(() => {
+                  if (client.readyState === WebSocket.OPEN) {
+                    client.ping();
+                  } else {
+                    clearInterval(pingInterval);
+                  }
+                }, 30_000);
+
+                let pongTimeout: NodeJS.Timeout;
+
+                client.on("pong", () => {
+                  clearTimeout(pongTimeout);
+                  pongTimeout = setTimeout(() => {
+                    clearInterval(pingInterval);
+                    client.terminate();
+                  }, 75_000);
+                });
+
+                client.on("close", () => {
+                  clearInterval(pingInterval);
+                  clearTimeout(pongTimeout);
+                });
+
+                if (client.readyState === WebSocket.OPEN) {
+                  client.ping();
+                }
+
                 (socket as any).user = user;
                 wsServer.emit("connection", client, request);
               },
@@ -91,7 +118,7 @@ export class CustomWsAdaptor extends WsAdapter {
           socket.destroy();
         }
       } catch (err) {
-        socket.end("HTTP/1.1 400\r\n" + err.message);
+        socket.end("HTTP/1.1 400\r\n" + (err as Error).message);
       }
     });
     return httpServer;


### PR DESCRIPTION
Introduce server-side websocket ping/pong behavior to ensure the websocket connection doesn't drop when no messages are sent from the server.

The numbers for ping/pong (30s ping interval, 75s pong timeout) are my best guess for acceptable values, allowing 2 pings plus response time before the server disconnects the client.

This PR is compatible with the current release version of Firebot (v5.65.4), but a change to Firebot should be made to also track the pings so the client can proactively reconnect incase the websocket connection still gets dropped.